### PR TITLE
Fix: Prevent active tab from being moved to second position when already first after tab close

### DIFF
--- a/bg.js
+++ b/bg.js
@@ -151,16 +151,20 @@ function isTabInaGroup(activeTab, windowTabs) {
  * @param {Array} windowTabs
  */
 function moveTabToFrontNotInGroup(activeTab, windowTabs) {
-	if (activeTab.groupId == -1) {
-		for (var index = 0; index < windowTabs.length; index++) {
-			var t = windowTabs[index];
-			if (t.id != activeTab.id) {
-				// don't await here, keep original behavior
-				moveTabById(activeTab.id, activeTab.windowId, t.index);
-				return;
-			}
-		}
-	}
+       if (activeTab.groupId == -1) {
+	       // If already at index 0, do nothing
+	       if (activeTab.index === 0) {
+		       return;
+	       }
+	       for (var index = 0; index < windowTabs.length; index++) {
+		       var t = windowTabs[index];
+		       if (t.id != activeTab.id) {
+			       // don't await here, keep original behavior
+			       moveTabById(activeTab.id, activeTab.windowId, t.index);
+			       return;
+		       }
+	       }
+       }
 }
 
 // Move a tab to the left or right edge of its group


### PR DESCRIPTION

https://github.com/user-attachments/assets/62b349f4-3102-40bc-8c67-ef9d5cf47e70

v2.0.2 contains a bug that moves the active tab to the second position after a tab is closed.

The bug occurs because, after a tab is closed, Chrome automatically activates the next tab, which may already be at index 0 (the first position). The extension's logic in `tabTimeout` checks if the active tab's `id` matches the `oldTabInfo.tabId` and then calls `moveTabToFrontNotInGroup`, which moves the tab to the index of the first tab that is not itself. This can result in the active tab being moved to index 1 (the second position) if it is already at index 0, because the function finds the next tab and moves the active tab to that tab's index.

#### Root cause
`moveTabToFrontNotInGroup` does not check if the active tab is already at index 0. When the active tab is already first, it still tries to move it, which can shift it to the second position.

#### Remedy:
Add a check in `moveTabToFrontNotInGroup` to do nothing if the active tab is already at index 0. This will prevent the tab from being moved unnecessarily.